### PR TITLE
build(go): reduce minimum version of Go to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arikkfir/justest
 
-go 1.22
+go 1.18
 
 require (
 	github.com/alecthomas/chroma/v2 v2.13.0


### PR DESCRIPTION
This change allows Go 1.18 to use this project by ensuring its syntax and tests work on that version upwards.

This is in preparation of the upcoming CI workflows which will validate this.