### PR TITLE
ci(github): add GitHub validation workflow

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -1,0 +1,30 @@
+name: Validation
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [ '1.21', '1.22' ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Download dependencies
+        run: go mod download -x
+
+      - name: Test
+        run: go test -v ./...

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,13 +5,10 @@
 This library has been tested on Go version 1.22 only. It should work on versions though, but this has not been tested.
 
 | Version | Supported          |
-| ------- | ------------------ |
+|---------|--------------------|
 | 1.22    | :white_check_mark: |
-| 1.21    | Probably           |
-| 1.20    | Probably           |
-| 1.19    | Probably           |
-| 1.18    | Probably           |
-| < 1.18  | :x:                |
+| 1.21    | :white_check_mark: |
+| < 1.21  | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arikkfir/justest
 
-go 1.18
+go 1.21
 
 require (
 	github.com/alecthomas/chroma/v2 v2.13.0


### PR DESCRIPTION
Add a GitHub validation workflow that runs tests across supported Go versions on every push to `main` branch as well as on every push to an open PR.