### PR TITLE
fix(stacktrace): stack-trace of failed tests print incorrect source locations

### DIFF
--- a/asserter.go
+++ b/asserter.go
@@ -291,7 +291,7 @@ func (a *assertion) Fatalf(format string, args ...any) {
 		callerFunction, callerFile, callerLine := caller.Location()
 
 		format = format + "\n%s:%d --> %s"
-		if matches, err := regexp.MatchString(`.*backend/internal/util/testing/justest\.`, callerFunction); err != nil {
+		if matches, err := regexp.MatchString(`.*/arikkfir/justest\.`, callerFunction); err != nil {
 			panic(fmt.Errorf("illegal regexp matching: %+v", err))
 		} else if matches {
 			// Caller is "justest" internal (e.g. "a.OrFail", "a.For", "a.Within") - only add the assertion location

--- a/location.go
+++ b/location.go
@@ -35,8 +35,8 @@ var (
 	}
 	ignoredStackTracePrefixes = []string{
 		"testing.",
-		"github.com/arikkfir/devbot/backend/internal/util/testing/justest/",
-		"github.com/arikkfir/devbot/backend/internal/util/testing/justest.",
+		"github.com/arikkfir/justest/",
+		"github.com/arikkfir/justest.",
 	}
 )
 


### PR DESCRIPTION
This change fixes the incorrect source location printing in failed test stack-traces.

The bug was caused by the graduation of this project into a standalone repository.