### PR TITLE
test: fix test flakiness due to reusing "for" loop variable in sub-tests

### DIFF
--- a/asserter_test.go
+++ b/asserter_test.go
@@ -87,6 +87,7 @@ func TestAssertionOrFail(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			defer VerifyTestOutcome(t, tc.expectedOutcome, tc.expectedOutcomePattern)
@@ -200,6 +201,7 @@ func TestAssertionFor(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			defer VerifyTestOutcome(t, tc.expectedOutcome, tc.expectedOutcomePattern)
@@ -320,6 +322,7 @@ func TestAssertionWithin(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			defer VerifyTestOutcome(t, tc.expectedOutcome, tc.expectedOutcomePattern)

--- a/matchers_be_between_test.go
+++ b/matchers_be_between_test.go
@@ -100,8 +100,11 @@ func TestBeBetween(t *testing.T) {
 		},
 	}
 	for kind, kindTestCases := range testCases {
+		kind := kind
+		kindTestCases := kindTestCases
 		t.Run(kind.String(), func(t *testing.T) {
 			for name, tc := range kindTestCases {
+				tc := tc
 				t.Run(name, func(t *testing.T) {
 					if tc.expectFailurePattern != nil {
 						defer VerifyTestOutcome(t, ExpectFailure, *tc.expectFailurePattern)

--- a/matchers_be_empty_test.go
+++ b/matchers_be_empty_test.go
@@ -28,6 +28,7 @@ func TestBeEmpty(t *testing.T) {
 		"Non-empty string fails": {actual: "abc", expectedOutcome: ExpectFailure, expectFailurePattern: regexp.QuoteMeta(`Expected 'abc' to be empty, but it is not (has a length of 3)`)},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			defer VerifyTestOutcome(t, tc.expectedOutcome, tc.expectFailurePattern)

--- a/matchers_be_greater_than_test.go
+++ b/matchers_be_greater_than_test.go
@@ -76,9 +76,12 @@ func TestBeGreaterThan(t *testing.T) {
 		},
 	}
 	for kind, kindTestCases := range testCases {
+		kind := kind
+		kindTestCases := kindTestCases
 		t.Run(kind.String(), func(t *testing.T) {
 			t.Parallel()
 			for name, tc := range kindTestCases {
+				tc := tc
 				t.Run(name, func(t *testing.T) {
 					t.Parallel()
 					if tc.expectFailurePattern != nil {

--- a/matchers_be_less_than_test.go
+++ b/matchers_be_less_than_test.go
@@ -76,9 +76,12 @@ func TestBeLessThan(t *testing.T) {
 		},
 	}
 	for kind, kindTestCases := range testCases {
+		kind := kind
+		kindTestCases := kindTestCases
 		t.Run(kind.String(), func(t *testing.T) {
 			t.Parallel()
 			for name, tc := range kindTestCases {
+				tc := tc
 				t.Run(name, func(t *testing.T) {
 					t.Parallel()
 					if tc.expectFailurePattern != nil {

--- a/matchers_equal_to_test.go
+++ b/matchers_equal_to_test.go
@@ -126,6 +126,7 @@ func TestEqualTo(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			defer VerifyTestOutcome(t, tc.expectedOutcome, tc.expectedFailurePattern)

--- a/matchers_fail_test.go
+++ b/matchers_fail_test.go
@@ -35,6 +35,7 @@ func TestFail(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			defer VerifyTestOutcome(t, tc.expectedOutcome, tc.expectFailurePattern)

--- a/matchers_not_test.go
+++ b/matchers_not_test.go
@@ -40,6 +40,7 @@ func TestNot(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			defer VerifyTestOutcome(t, tc.expectedOutcome, tc.expectFailurePattern)

--- a/matchers_say_test.go
+++ b/matchers_say_test.go
@@ -49,6 +49,7 @@ func TestSay(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			defer VerifyTestOutcome(t, tc.expectedOutcome, tc.expectFailurePattern)

--- a/matchers_succeed_test.go
+++ b/matchers_succeed_test.go
@@ -29,6 +29,7 @@ func TestSucceed(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			defer VerifyTestOutcome(t, tc.expectedOutcome, tc.expectFailurePattern)

--- a/value_extractor_base_test.go
+++ b/value_extractor_base_test.go
@@ -73,6 +73,7 @@ func TestValueExtractor(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			mt := NewMockT(t)
@@ -172,6 +173,7 @@ func TestNewChannelExtractor(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			mt := NewMockT(t)
@@ -235,6 +237,7 @@ func TestNewPointerExtractor(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			mt := NewMockT(t)
@@ -382,6 +385,7 @@ func TestNewFuncExtractor(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			mt := NewMockT(t)

--- a/value_extractor_numeric_test.go
+++ b/value_extractor_numeric_test.go
@@ -37,6 +37,7 @@ func TestNumericValueExtractor(t *testing.T) {
 		"uint64":               {actual: uint64(1), expectedOutcome: ExpectSuccess, expected: uint64(1)},
 	}
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			defer VerifyTestOutcome(t, tc.expectedOutcome, tc.expectedOutcomePattern)


### PR DESCRIPTION
This change fixes test flakiness caused to due "for" loops reusing the same loop variable in parallel tests.