### PR TITLE
security(dependencies): enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "security(dependencies): "
+    labels:
+      - "security"
+      - "dependencies"


### PR DESCRIPTION
This change enables Dependabot on this repository, to ensure we keep our dependencies up to date.