### PR TITLE
build(go): fix go directive to use 1.N.P syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arikkfir/justest
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/alecthomas/chroma/v2 v2.13.0


### PR DESCRIPTION
As of Go 1.21 the syntax for the "go" directive must be 1.N.P