### PR TITLE
feat(fail): show mismatched error message on error

### DIFF
--- a/matchers_fail.go
+++ b/matchers_fail.go
@@ -7,6 +7,9 @@ import (
 
 //go:noinline
 func Fail(patterns ...string) Matcher {
+	const failureFormatMsg = `Error message did not match any pattern:
+	Patterns: %v
+	Error:    %s`
 	return MatcherFunc(func(t T, actuals ...any) {
 		GetHelper(t).Helper()
 
@@ -23,13 +26,14 @@ func Fail(patterns ...string) Matcher {
 		lastRT := reflect.TypeOf(last)
 		if lastRT.AssignableTo(reflect.TypeOf((*error)(nil)).Elem()) {
 			if len(patterns) > 0 {
+				msg := last.(error).Error()
 				for _, pattern := range patterns {
 					re := regexp.MustCompile(pattern)
-					if re.MatchString(last.(error).Error()) {
+					if re.MatchString(msg) {
 						return
 					}
 				}
-				t.Fatalf("Error message did not match any of these patterns: %v", patterns)
+				t.Fatalf(failureFormatMsg, patterns, msg)
 			} else {
 				return
 			}

--- a/matchers_fail_test.go
+++ b/matchers_fail_test.go
@@ -50,7 +50,7 @@ func TestFail(t *testing.T) {
 	t.Run("Fails if error matches none of the patterns", func(t *testing.T) {
 		t.Parallel()
 		mt := NewMockT(t)
-		defer mt.Verify(FailureVerifier(regexp.QuoteMeta(`Error message did not match any of these patterns: [^abc$ ^def$ ^ghi$]`)))
+		defer mt.Verify(FailureVerifier(`.*` + regexp.QuoteMeta(`[^abc$ ^def$ ^ghi$]`) + `\n.*expected error`))
 		With(mt).Verify(fmt.Errorf("expected error")).Will(Fail(`^abc$`, `^def$`, `^ghi$`)).OrFail()
 	})
 }


### PR DESCRIPTION
This change makes the "Fail" matcher print the mismatched error message when it doesn't match any pattern.

This makes it easier to debug failing tests when the error does not match any of the patterns, but you don't know what error was actually provided.