### PR TITLE
fix(equalto): go-cmp opts were not passed to failure diff

### DIFF
--- a/matchers_equal_to.go
+++ b/matchers_equal_to.go
@@ -53,7 +53,7 @@ func EqualTo(expected ...any) EqualToMatcher {
 		comparator: func(t T, expected, actual any) {
 			GetHelper(t).Helper()
 			if !cmp.Equal(expected, actual, opts...) {
-				t.Fatalf("Unexpected difference (\"-\" lines are expected values; \"+\" lines are actual values):\n%s", strings.TrimSpace(cmp.Diff(expected, actual)))
+				t.Fatalf("Unexpected difference (\"-\" lines are expected values; \"+\" lines are actual values):\n%s", strings.TrimSpace(cmp.Diff(expected, actual, opts...)))
 			}
 		},
 	}

--- a/matchers_equal_to_test.go
+++ b/matchers_equal_to_test.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	. "github.com/arikkfir/justest"
 )
 
@@ -39,6 +41,27 @@ func TestEqualTo(t *testing.T) {
 				actuals:  []any{1},
 				expected: []any{1, 2},
 				verifier: FailureVerifier(`^Unexpected difference: received 1 actual values and 2 expected values.*`),
+			},
+			"Failure diff uses opts": {
+				actuals: []any{
+					struct {
+						Public  string
+						private string
+					}{
+						Public:  "public-value",
+						private: "private-value",
+					},
+				},
+				expected: []any{
+					struct {
+						Public  string
+						private string
+					}{Public: "incorrect-value", private: "private-value"},
+					cmpopts.IgnoreUnexported(struct {
+						Public  string
+						private string
+					}{})},
+				verifier: FailureVerifier(regexp.QuoteMeta(`Unexpected difference ("-" lines are expected values; "+" lines are actual values):`) + "\n.*"),
 			},
 		}
 		for name, tc := range testCases {


### PR DESCRIPTION
This change passes any given go-cmp Opt instances to the `cmp.Diff` call and not only to the cmp.Equal function.

This fixes a potential panic that can happen when structs with unexported fields are given as actual & expected values.