### PR TITLE
feat: support naming assertions to help describe their purpose

### DIFF
--- a/asserter_test.go
+++ b/asserter_test.go
@@ -22,6 +22,12 @@ func TestWith(t *testing.T) {
 		}()
 		With(nil)
 	})
+	t.Run("description propagated to failure message", func(t *testing.T) {
+		t.Parallel()
+		mt := NewMockT(t)
+		defer mt.Verify(FailureVerifier("^user feature failed: unexpected.*"))
+		With(mt).Ensure("user feature").Verify(1).Will(EqualTo(2)).OrFail()
+	})
 }
 
 func TestCorrectActualsPassedToMatcher(t *testing.T) {


### PR DESCRIPTION
This change adds a new "Ensure(string)" function to the "Verifier" interface. This method will apply a description to the current verifier which will be prepended to potential failures, should those happen.

Usage:

    With(t).Ensure("my feature should yield a popup").Verify(...)...