### PR TITLE
feat: support slowing down tests to enable debugging consequences

### DIFF
--- a/asserter.go
+++ b/asserter.go
@@ -10,6 +10,8 @@ import (
 	"github.com/arikkfir/justest/internal"
 )
 
+const SlowFactorEnvVarName = "JUSTEST_SLOW_FACTOR"
+
 //go:noinline
 func With(t T) VerifierAndEnsurer {
 	if t == nil {
@@ -109,6 +111,8 @@ func (a *assertion) OrFail() {
 //go:noinline
 func (a *assertion) For(duration time.Duration, interval time.Duration) {
 	GetHelper(a.t).Helper()
+	duration = transformDurationIfNecessary(a.t, duration)
+
 	if a.evaluated {
 		panic("assertion already evaluated")
 	} else {
@@ -194,6 +198,8 @@ func (a *assertion) For(duration time.Duration, interval time.Duration) {
 //go:noinline
 func (a *assertion) Within(duration time.Duration, interval time.Duration) {
 	GetHelper(a.t).Helper()
+	duration = transformDurationIfNecessary(a.t, duration)
+
 	if a.evaluated {
 		panic("assertion already evaluated")
 	} else {

--- a/util.go
+++ b/util.go
@@ -1,0 +1,21 @@
+package justest
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+func transformDurationIfNecessary(t T, d time.Duration) time.Duration {
+	if v, found := os.LookupEnv(SlowFactorEnvVarName); found {
+		if factor, err := strconv.ParseInt(v, 0, 0); err != nil {
+			t.Logf("Ignoring value of '%s' environment variable: %+v", SlowFactorEnvVarName, err)
+			return d
+		} else {
+			oldSeconds := int64(d.Seconds())
+			newSeconds := oldSeconds * factor
+			return time.Duration(newSeconds) * time.Second
+		}
+	}
+	return d
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,14 @@
+package justest
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTransformDurationIfNecessary(t *testing.T) {
+	With(t).Verify(transformDurationIfNecessary(t, 5*time.Second)).Will(EqualTo(5 * time.Second)).OrFail()
+	t.Setenv(SlowFactorEnvVarName, "2")
+	With(t).Verify(transformDurationIfNecessary(t, 5*time.Second)).Will(EqualTo(10 * time.Second)).OrFail()
+	t.Setenv(SlowFactorEnvVarName, "3")
+	With(t).Verify(transformDurationIfNecessary(t, 5*time.Second)).Will(EqualTo(15 * time.Second)).OrFail()
+}


### PR DESCRIPTION
This change introduces a supported environment variable called `JUSTEST_SLOW_FACTOR` which, when set to an integer value, will cause Justest to multiple durations passed to the `For(...)` and `Within(...)` methods with its value. 

This will cause these duration to be longer, thus allowing the developer to investigate or debug side consequences of such tests - like logging into clusters and checking the effects of end-to-end tests, inspecting file-systems, etc.