### PR TITLE
refactor: refactor fluent API & source printing for better readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,48 +43,48 @@ import (
 func TestSomething(t *testing.T) {
 	
 	// Simple assertions
-	With(t).Verify(1).Will(BeBetween(0, 2)).OrFail()
-	With(t).Verify("").Will(BeEmpty()).OrFail()
-	With(t).Verify([]int{1,2,3}).Will(BeEmpty()).OrFail() // <-- This will fail!
-	With(t).Verify(1).Will(BeGreaterThan(0)).OrFail()
-	With(t).Verify(1).Will(BeLessThan(2)).OrFail()
-	With(t).Verify("abc").Will(BeNil()).OrFail() // <-- This will fail!
-	With(t).Verify(1).Will(EqualTo(1)).OrFail()
-	With(t).Verify("abc").Will(EqualTo("def")).OrFail() // <-- This will fail!
+	With(t).VerifyThat(1).Will(BeBetween(0, 2)).Now()
+	With(t).VerifyThat("").Will(BeEmpty()).Now()
+	With(t).VerifyThat([]int{1, 2, 3}).Will(BeEmpty()).Now() // <-- This will fail!
+	With(t).VerifyThat(1).Will(BeGreaterThan(0)).Now()
+	With(t).VerifyThat(1).Will(BeLessThan(2)).Now()
+	With(t).VerifyThat("abc").Will(BeNil()).Now() // <-- This will fail!
+	With(t).VerifyThat(1).Will(EqualTo(1)).Now()
+	With(t).VerifyThat("abc").Will(EqualTo("def")).Now() // <-- This will fail!
 
 	// Assert success or failure of a function (functions can have any set of return values or none at all)
 	succeedingFunc := func() (string, error) { return "abc", nil }
-	With(t).Verify(succeedingFunc).Will(Succeed()).OrFail() // <-- Will succeed since error return value is nil
-	With(t).Verify(succeedingFunc).Will(Fail()).OrFail() // <-- Will fail since it expects error return value to be non-nil
+	With(t).VerifyThat(succeedingFunc).Will(Succeed()).Now() // <-- Will succeed since error return value is nil
+	With(t).VerifyThat(succeedingFunc).Will(Fail()).Now()    // <-- Will fail since it expects error return value to be non-nil
 	failingFunc := func() (string, error) { return "", fmt.Errorf("error") }
-	With(t).Verify(failingFunc).Will(Succeed()).OrFail() // <-- Will fail since error return value is not nil
-	With(t).Verify(failingFunc).Will(Fail()).OrFail() // <-- Will succeed since it expects error return value to be non-nil
+	With(t).VerifyThat(failingFunc).Will(Succeed()).Now() // <-- Will fail since error return value is not nil
+	With(t).VerifyThat(failingFunc).Will(Fail()).Now()    // <-- Will succeed since it expects error return value to be non-nil
 
 	// Assert negation of another assertion
-	With(t).Verify(1).Will(Not(EqualTo(2))).OrFail()
+	With(t).VerifyThat(1).Will(Not(EqualTo(2))).Now()
 	
 	// Assert something will **eventually** match
 	// It will stop when the function succeeds (no assertion failure) or when time runs out
-	With(t).Verify(func(t T) {
+	With(t).VerifyThat(func(t T) {
 
 		// Will be invoked every 100ms until either it no longer fails or until time runs out (10s)
-		With(t).Verify(2).Will(EqualTo(2)).OrFail()
+		With(t).VerifyThat(2).Will(EqualTo(2)).Now()
 
 	}).Will(Succeed()).Within(10*time.Second, 100*time.Millisecond)
 
 	// Assert something will **repeatedly** match for a certain amount of time
 	// It will stop on the first time the function fails
-	With(t).Verify(func(t T) {
+	With(t).VerifyThat(func(t T) {
 
 		// Will be invoked every 100ms until either it fails or until time runs out (10s)
-		With(t).Verify(2).Will(EqualTo(2)).OrFail()
+		With(t).VerifyThat(2).Will(EqualTo(2)).Now()
 
 	}).Will(Succeed()).For(10*time.Second, 100*time.Millisecond)
 
 	// Assert on text patterns
-	With(t).Verify("abc").Will(Say("^a*c$")).OrFail()
-	With(t).Verify("abc").Will(Say(regexp.MustCompile("^a*c$"))).OrFail()
-	With(t).Verify([]byte("abc")).Will(Say("^a*c$")).OrFail()
+	With(t).VerifyThat("abc").Will(Say("^a*c$")).Now()
+	With(t).VerifyThat("abc").Will(Say(regexp.MustCompile("^a*c$"))).Now()
+	With(t).VerifyThat([]byte("abc")).Will(Say("^a*c$")).Now()
 }
 ```
 
@@ -105,7 +105,7 @@ var (
 	myValueExtractor = NewValueExtractor(ExtractSameValue)
 )
 
-// BeSuperDuper returns a matcher that will ensure that each actual value passed to "With(t).Verify(...)" will be either
+// BeSuperDuper returns a matcher that will ensure that each actual value passed to "With(t).VerifyThat(...)" will be either
 // "super duper" or "extra super duper", depending on the value of the `extraDuper` parameter.
 func BeSuperDuper(extraDuper bool) Matcher {
 	return MatcherFunc(func(t T, actuals ...any) {

--- a/matchers_be_between_test.go
+++ b/matchers_be_between_test.go
@@ -108,7 +108,7 @@ func TestBeBetween(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					mt := NewMockT(t)
 					defer mt.Verify(tc.verifier)
-					With(mt).Verify(tc.actual).Will(BeBetween(tc.min, tc.max)).OrFail()
+					With(mt).VerifyThat(tc.actual).Will(BeBetween(tc.min, tc.max)).Now()
 				})
 			}
 		})
@@ -117,12 +117,12 @@ func TestBeBetween(t *testing.T) {
 		t.Parallel()
 		mt := NewMockT(t)
 		defer mt.Verify(FailureVerifier(`Expected actual value to be of type 'int64', but it is of type 'int'`))
-		With(mt).Verify(1).Will(BeBetween(0, int64(9))).OrFail()
+		With(mt).VerifyThat(1).Will(BeBetween(0, int64(9))).Now()
 	})
 	t.Run("MinTypeMismatches", func(t *testing.T) {
 		t.Parallel()
 		mt := NewMockT(t)
 		defer mt.Verify(FailureVerifier(`Expected actual value to be of type 'int64', but it is of type 'int'`))
-		With(mt).Verify(1).Will(BeBetween(int64(0), 9)).OrFail()
+		With(mt).VerifyThat(1).Will(BeBetween(int64(0), 9)).Now()
 	})
 }

--- a/matchers_be_empty_test.go
+++ b/matchers_be_empty_test.go
@@ -33,7 +33,7 @@ func TestBeEmpty(t *testing.T) {
 			t.Parallel()
 			mt := NewMockT(t)
 			defer mt.Verify(tc.verifier)
-			With(mt).Verify(tc.actual).Will(BeEmpty()).OrFail()
+			With(mt).VerifyThat(tc.actual).Will(BeEmpty()).Now()
 		})
 	}
 }

--- a/matchers_be_greater_than_test.go
+++ b/matchers_be_greater_than_test.go
@@ -86,7 +86,7 @@ func TestBeGreaterThan(t *testing.T) {
 					t.Parallel()
 					mt := NewMockT(t)
 					defer mt.Verify(tc.verifier)
-					With(mt).Verify(tc.actual).Will(BeGreaterThan(tc.min)).OrFail()
+					With(mt).VerifyThat(tc.actual).Will(BeGreaterThan(tc.min)).Now()
 				})
 			}
 		})
@@ -95,6 +95,6 @@ func TestBeGreaterThan(t *testing.T) {
 		t.Parallel()
 		mt := NewMockT(t)
 		defer mt.Verify(FailureVerifier(`Expected actual value to be of type 'int64', but it is of type 'int'`))
-		With(mt).Verify(1).Will(BeGreaterThan(int64(0))).OrFail()
+		With(mt).VerifyThat(1).Will(BeGreaterThan(int64(0))).Now()
 	})
 }

--- a/matchers_be_less_than_test.go
+++ b/matchers_be_less_than_test.go
@@ -86,7 +86,7 @@ func TestBeLessThan(t *testing.T) {
 					t.Parallel()
 					mt := NewMockT(t)
 					defer mt.Verify(tc.verifier)
-					With(mt).Verify(tc.actual).Will(BeLessThan(tc.max)).OrFail()
+					With(mt).VerifyThat(tc.actual).Will(BeLessThan(tc.max)).Now()
 				})
 			}
 		})
@@ -95,6 +95,6 @@ func TestBeLessThan(t *testing.T) {
 		t.Parallel()
 		mt := NewMockT(t)
 		defer mt.Verify(FailureVerifier(`Expected actual value to be of type 'int64', but it is of type 'int'`))
-		With(mt).Verify(1).Will(BeLessThan(int64(0))).OrFail()
+		With(mt).VerifyThat(1).Will(BeLessThan(int64(0))).Now()
 	})
 }

--- a/matchers_be_nil_test.go
+++ b/matchers_be_nil_test.go
@@ -12,12 +12,12 @@ func TestBeNil(t *testing.T) {
 		t.Parallel()
 		mt := NewMockT(t)
 		defer mt.Verify(SuccessVerifier())
-		With(mt).Verify(nil).Will(BeNil()).OrFail()
+		With(mt).VerifyThat(nil).Will(BeNil()).Now()
 	})
 	t.Run("Not nil", func(t *testing.T) {
 		t.Parallel()
 		mt := NewMockT(t)
 		defer mt.Verify(FailureVerifier(`Expected actual to be nil, but it is not: abc`))
-		With(mt).Verify("abc").Will(BeNil()).OrFail()
+		With(mt).VerifyThat("abc").Will(BeNil()).Now()
 	})
 }

--- a/matchers_equal_to_test.go
+++ b/matchers_equal_to_test.go
@@ -70,7 +70,7 @@ func TestEqualTo(t *testing.T) {
 				t.Parallel()
 				mt := NewMockT(t)
 				defer mt.Verify(tc.verifier)
-				With(mt).Verify(tc.actuals...).Will(EqualTo(tc.expected...)).OrFail()
+				With(mt).VerifyThat(tc.actuals...).Will(EqualTo(tc.expected...)).Now()
 			})
 		}
 	})
@@ -169,7 +169,7 @@ func TestEqualTo(t *testing.T) {
 				mt := NewMockT(t)
 				defer mt.Verify(tc.outcomeVerifier)
 				comparatorFunc, verifierFunc := tc.comparatorFactory(mt, &tc)
-				With(mt).Verify(tc.actuals...).Will(EqualTo(tc.expected...).Using(comparatorFunc)).OrFail()
+				With(mt).VerifyThat(tc.actuals...).Will(EqualTo(tc.expected...).Using(comparatorFunc)).Now()
 				if verifierFunc != nil {
 					verifierFunc()
 				}

--- a/matchers_fail_test.go
+++ b/matchers_fail_test.go
@@ -38,19 +38,19 @@ func TestFail(t *testing.T) {
 			t.Parallel()
 			mt := NewMockT(t)
 			defer mt.Verify(tc.verifier)
-			With(mt).Verify(tc.actuals...).Will(Fail()).OrFail()
+			With(mt).VerifyThat(tc.actuals...).Will(Fail()).Now()
 		})
 	}
 	t.Run("Succeeds if error matches one of the patterns", func(t *testing.T) {
 		t.Parallel()
 		mt := NewMockT(t)
 		defer mt.Verify(SuccessVerifier())
-		With(mt).Verify(fmt.Errorf("expected error")).Will(Fail(`^expected error$`)).OrFail()
+		With(mt).VerifyThat(fmt.Errorf("expected error")).Will(Fail(`^expected error$`)).Now()
 	})
 	t.Run("Fails if error matches none of the patterns", func(t *testing.T) {
 		t.Parallel()
 		mt := NewMockT(t)
 		defer mt.Verify(FailureVerifier(`.*` + regexp.QuoteMeta(`[^abc$ ^def$ ^ghi$]`) + `\n.*expected error`))
-		With(mt).Verify(fmt.Errorf("expected error")).Will(Fail(`^abc$`, `^def$`, `^ghi$`)).OrFail()
+		With(mt).VerifyThat(fmt.Errorf("expected error")).Will(Fail(`^abc$`, `^def$`, `^ghi$`)).Now()
 	})
 }

--- a/matchers_not.go
+++ b/matchers_not.go
@@ -69,7 +69,7 @@ func Not(m Matcher) Matcher {
 					panic(fmt.Errorf("unexpected panic: %+v", r))
 				}
 			} else {
-				t.Fatalf("Expected this matcher to fail, but it did not")
+				t.Fatalf("Expected mismatch did not happen")
 			}
 		}()
 

--- a/matchers_not_test.go
+++ b/matchers_not_test.go
@@ -21,7 +21,7 @@ func TestNot(t *testing.T) {
 		"Successful matcher fails": {
 			actuals:  []any{"foo-bar"},
 			matcher:  MatcherFunc(func(t T, actual ...any) {}),
-			verifier: FailureVerifier(`Expected this matcher to fail, but it did not`),
+			verifier: FailureVerifier(`Expected mismatch did not happen`),
 		},
 		"Panicking matcher re-panics": {
 			actuals:  []any{"foo-bar"},
@@ -35,7 +35,7 @@ func TestNot(t *testing.T) {
 			t.Parallel()
 			mt := NewMockT(t)
 			defer mt.Verify(tc.verifier)
-			With(mt).Verify(tc.actuals...).Will(Not(tc.matcher)).OrFail()
+			With(mt).VerifyThat(tc.actuals...).Will(Not(tc.matcher)).Now()
 		})
 	}
 }

--- a/matchers_say_test.go
+++ b/matchers_say_test.go
@@ -29,8 +29,8 @@ func TestSay(t *testing.T) {
 			t.Parallel()
 			mt := NewMockT(t)
 			defer mt.Verify(tc.verifier)
-			With(mt).Verify(tc.actuals...).Will(Say(tc.expected)).OrFail()
-			With(mt).Verify(tc.actuals...).Will(Say(regexp.MustCompile(tc.expected))).OrFail()
+			With(mt).VerifyThat(tc.actuals...).Will(Say(tc.expected)).Now()
+			With(mt).VerifyThat(tc.actuals...).Will(Say(regexp.MustCompile(tc.expected))).Now()
 		})
 	}
 }

--- a/matchers_succeed_test.go
+++ b/matchers_succeed_test.go
@@ -24,7 +24,7 @@ func TestSucceed(t *testing.T) {
 			t.Parallel()
 			mt := NewMockT(t)
 			defer mt.Verify(tc.verifier)
-			With(mt).Verify(tc.actuals...).Will(Succeed()).OrFail()
+			With(mt).VerifyThat(tc.actuals...).Will(Succeed()).Now()
 		})
 	}
 }

--- a/util.go
+++ b/util.go
@@ -3,6 +3,7 @@ package justest
 import (
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -18,4 +19,15 @@ func transformDurationIfNecessary(t T, d time.Duration) time.Duration {
 		}
 	}
 	return d
+}
+
+func indentIfMultiLine(s string) string {
+	if strings.Contains(s, "\n") {
+		lines := strings.Split(s, "\n")
+		for i, line := range lines {
+			lines[i] = "\t" + line
+		}
+		return "\n" + strings.Join(lines, "\n")
+	}
+	return s
 }

--- a/util_test.go
+++ b/util_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func TestTransformDurationIfNecessary(t *testing.T) {
-	With(t).Verify(transformDurationIfNecessary(t, 5*time.Second)).Will(EqualTo(5 * time.Second)).OrFail()
+	With(t).VerifyThat(transformDurationIfNecessary(t, 5*time.Second)).Will(EqualTo(5 * time.Second)).Now()
 	t.Setenv(SlowFactorEnvVarName, "2")
-	With(t).Verify(transformDurationIfNecessary(t, 5*time.Second)).Will(EqualTo(10 * time.Second)).OrFail()
+	With(t).VerifyThat(transformDurationIfNecessary(t, 5*time.Second)).Will(EqualTo(10 * time.Second)).Now()
 	t.Setenv(SlowFactorEnvVarName, "3")
-	With(t).Verify(transformDurationIfNecessary(t, 5*time.Second)).Will(EqualTo(15 * time.Second)).OrFail()
+	With(t).VerifyThat(transformDurationIfNecessary(t, 5*time.Second)).Will(EqualTo(15 * time.Second)).Now()
 }


### PR DESCRIPTION
This change refactors the fluent API of the package to make the test source code flow better in terms of readability. For example, instead of:

```go
With(t).Verify(1).Will(EqualTo(2)).OrFail()
```

The API is now either:

```go
With(t).EnsureThat("1 equals 2").ByVerifying(1).Will(EqualTo(2)).Now()
With(t).VerifyThat(1).Will(EqualTo(2)).Now()
```

The call to "EnsureThat" is optional and is meant to help documenting the test in case of failures. The change from ".OrFail()" to ".Now()" ensures that every assertion ends with a timing specification:

```go
With(t).VerifyThat(1).Will(EqualTo(2)).Now()
With(t).VerifyThat(1).Will(EqualTo(2)).For(...)
With(t).VerifyThat(1).Will(EqualTo(2))Within(...)
```

Additionally, this refactor improves the printing of the assertion's source code location, enabling support for multi-line location source code. For instance, for the following assertion:

```go
With(t).
    EnsureThat("...").
    ByVerifying(1).
    Will(EqualTo(2)).
    Now()
```

Previous versions only printed the line containing the "Now()" call, but this version will print the entire statement (from the "With(t)" up to and including the call to "Now()".)