### PR TITLE
fix(highlight): parsing of JUSTEST_DISABLE_SOURCE_HIGHLIGHT is wrong

### DIFF
--- a/location.go
+++ b/location.go
@@ -155,7 +155,7 @@ func init() {
 		if val, err := strconv.ParseBool(highlightEnv); err != nil {
 			panic(fmt.Sprintf("Error parsing JUSTEST_HIGHLIGHT_SOURCE environment variable - illegal value: %s", highlightEnv))
 		} else {
-			highlight = val
+			highlight = !val
 		}
 	}
 


### PR DESCRIPTION
This change fixes the parsing of the `JUSTEST_DISABLE_SOURCE_HIGHLIGHT` environment variable. Now, setting `true`, `True`, `TRUE`, `1`, or `T` will disable source code highlighting, as one would expect given the environment variable's name.

Before this fix, only setting it to `false`, `False`, `FALSE`, `0` or `F` would have turned off source code highlighting, which is the exact opposite of the environment variable name.